### PR TITLE
Prevent objects from registering the same observer more than once.

### DIFF
--- a/ESCObservable/ESCObserversProxy.m
+++ b/ESCObservable/ESCObserversProxy.m
@@ -30,8 +30,8 @@
 - (BOOL)isEqual:(ESCObserverWeakWrapper *)object
 {
     BOOL equalTargets = [self.target isEqual:object.target];
-    BOOL equalSelectors = YES;
-    BOOL equalForwardToSelectors = YES;
+    BOOL equalSelectors = !self.selector && !object.selector;
+    BOOL equalForwardToSelectors = !self.forwardToSelector && !object.forwardToSelector;
     
     if (self.selector && object.selector) {
         equalSelectors = [NSStringFromSelector(self.selector) isEqualToString:NSStringFromSelector(object.selector)];

--- a/ESCObservable/tests/ESCObservableTest.m
+++ b/ESCObservable/tests/ESCObservableTest.m
@@ -390,4 +390,49 @@
 	[self.mockObserver1 verify];
 }
 
+- (void)testObserversOfTheSameTargetCannotBeAddedMoreThanOnce {
+    ESCTestObservable *testObject = [[ESCTestObservable alloc] init];
+    
+    id mockObserver = [OCMockObject niceMockForProtocol:@protocol(ESCObservableTestObserver)];
+    [testObject escAddObserver:mockObserver];
+    [testObject escAddObserver:mockObserver];
+    
+    [[mockObserver expect] testMessageWithNoParameters];
+    [[mockObserver reject] testMessageWithNoParameters];
+    
+    [testObject sendTestMessageWithNoParameters];
+    
+    [mockObserver verify];
+}
+
+- (void)testObserversOfTheSameTargetAndSelectorCannotBeAddedMoreThanOnce {
+    ESCTestObservable *testObject = [[ESCTestObservable alloc] init];
+    
+    id mockObserver = [OCMockObject niceMockForProtocol:@protocol(ESCObservableTestObserver)];
+    [testObject escAddObserver:mockObserver forSelector:@selector(testMessageWithNoParameters)];
+    [testObject escAddObserver:mockObserver forSelector:@selector(testMessageWithNoParameters)];
+    
+    [[mockObserver expect] testMessageWithNoParameters];
+    [[mockObserver reject] testMessageWithNoParameters];
+    
+    [testObject sendTestMessageWithNoParameters];
+    
+    [mockObserver verify];
+}
+
+- (void)testObserversOfTheSameTargetAndSelectorAndForwardSelectorCannotBeAddedMoreThanOnce {
+    ESCTestObservable *testObject = [[ESCTestObservable alloc] init];
+    
+    id mockObserver = [OCMockObject niceMockForProtocol:@protocol(ESCObservableTestForwardingSelectors)];
+    [testObject escAddObserver:mockObserver forSelector:@selector(testMessageWithNoParameters) forwardingToSelector:@selector(forwardedMessage)];
+    [testObject escAddObserver:mockObserver forSelector:@selector(testMessageWithNoParameters) forwardingToSelector:@selector(forwardedMessage)];
+    
+    [[mockObserver expect] forwardedMessage];
+    [[mockObserver reject] forwardedMessage];
+    
+    [testObject sendTestMessageWithNoParameters];
+    
+    [mockObserver verify];
+}
+
 @end

--- a/ESCObservable/tests/ESCObservableTest.m
+++ b/ESCObservable/tests/ESCObservableTest.m
@@ -435,4 +435,21 @@
     [mockObserver verify];
 }
 
+- (void)testMultipleObserversOfTheSameTargetWithVaryingAttributesCanBeSimultaneouslyAdded {
+    ESCTestObservable *testObject = [[ESCTestObservable alloc] init];
+    
+    id mockObserver = [OCMockObject niceMockForProtocol:@protocol(ESCObservableTestObserver)];
+    [testObject escAddObserver:mockObserver];
+    [testObject escAddObserver:mockObserver forSelector:@selector(testMessageWithNoParameters)];
+    [testObject escAddObserver:mockObserver forSelector:@selector(testMessageWithNoParameters) forwardingToSelector:@selector(testOptionalMessageWithNoParameters)];
+    
+    [[mockObserver expect] testMessageWithNoParameters];
+    [[mockObserver expect] testMessageWithNoParameters];
+    [[mockObserver expect] testOptionalMessageWithNoParameters];
+    
+    [testObject sendTestMessageWithNoParameters];
+    
+    [mockObserver verify];
+}
+
 @end


### PR DESCRIPTION
This could lead to unintended side effects and difficult to track down bugs.

We ran into this problem on my team and were under the assumption that this wouldn't happen. Digging into the source code of `ESCObservable` I realized that you can have duplicate observers for the same object. This seems like a bug and not a feature (at least by our assessment), so I whipped up a quick fix to prevent that.
