### PR TITLE
Fixes clang analyzer warning regarding potential objc_method_description garbage value

### DIFF
--- a/ESCObservable/ESCObserversProxy.m
+++ b/ESCObservable/ESCObserversProxy.m
@@ -96,7 +96,7 @@
 }
 
 - (struct objc_method_description)descriptionForSelector:(SEL)selector {
-    struct objc_method_description description;
+    struct objc_method_description description = {NULL, NULL};
     for (Protocol *protocol in self.escObserverProtocols) {
         description = protocol_getMethodDescription(protocol, selector, NO, YES);
         if (description.name == NULL) {


### PR DESCRIPTION
Our OS X Mavericks Xcode Server has 1 analysis warning, which is coming from our ESCObservable pod. This commit fixes that issue.

```
ESCObservable/ESCObserversProxy.m:109:26: The left operand of '==' is a garbage value
```
